### PR TITLE
Reorganize UI elements into menu

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,12 @@ const editor = createJSONEditor({
     }
 });
 
+let jsonEditor = document.getElementById("jsoneditor"); // JSON editor HTML Element
+// If user had JSON editor open upon last visit, open by default
+if (localStorage.getItem("jsonEditor") == "open") {
+    jsonEditor.style.display = "flex";
+}
+
 //Defined in selectionBuffer/selectionBuffer.js
 //Keeps track of selected elements
 const selectionBuffer = new SelectionBuffer();
@@ -150,6 +156,10 @@ function initializeGraph(graphData, paper, graph)
     const toggleDependencyButton = new FunctionButton(0, 75, 80, 20, "Toggle Dep", toggleDependency, [selectionBuffer, runtimeGraphData, graph]);
     functionButtons[toggleDependencyButton.uuid] = toggleDependencyButton;
     toggleDependencyButton.JointRect.addTo(graph);
+
+    const advancedButton = new FunctionButton(0, 100, 80, 20, "Toggle Adv", toggleJSONEditor, [selectionBuffer, runtimeGraphData, graph]);
+    functionButtons[advancedButton.uuid] = advancedButton;
+    advancedButton.JointRect.addTo(graph);
 
     runtimeGraphData.functionButtons = functionButtons;
 }
@@ -483,6 +493,19 @@ function addNewDependency(sourceElem, targetElem, runtimeGraphData, graph)
 
     runtimeGraphData.graphLinks[newDepUUID] = CausalDependency.addLinkToGraph(addDepJSON, graph, runtimeGraphData.graphElements);
     runtimeGraphData.graphLinks[newDepUUID].updateSelection();
+}
+
+/**
+ * Toggles the JSON editor between open/closed.
+ */
+function toggleJSONEditor() {
+    if (jsonEditor.style.display == "none" || jsonEditor.style.display == "") {
+        jsonEditor.style.display = "flex"; // Open editor
+        localStorage.setItem("jsonEditor", "open"); // Save preference
+    } else {
+        jsonEditor.style.display = "none"; // Close editor
+        localStorage.setItem("jsonEditor", "closed"); // Save preference
+    }
 }
 
 /**

--- a/static/index.html
+++ b/static/index.html
@@ -8,7 +8,13 @@
     <body>
 
         <div class="cdd-editor">
-            <div id="jointjspaper" class="cdd-editor left"><!-- This is used by index.js to attach the JointJS Paper object, for displaying CDDs. --></div>
+            <div class="cdd-editor left">
+                <div id="jointjspaper" class="cdd-editor"><!-- This is used by index.js to attach the JointJS Paper object, for displaying CDDs. --></div>
+                <div id="controls-legend">
+                    <b>Left click:</b> Select single element <br/>
+                    <b>Right click:</b> Select multiple elements <br/>
+                </div>
+            </div>
             <div id="jsoneditor" class="cdd-editor right"><!-- This is used by index.js to attach the JSON Editor object. --></div>
         </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -10,14 +10,65 @@
         <div class="cdd-editor">
             <div class="cdd-editor left">
                 <div id="jointjspaper" class="cdd-editor"><!-- This is used by index.js to attach the JointJS Paper object, for displaying CDDs. --></div>
-                <div id="controls-legend">
+                <div id="controls-legend"> <!--Display graph control options over graph-->
                     <b>Left click:</b> Select single element <br/>
+                    <b>Left click (drag):</b> Move single element <br />
                     <b>Right click:</b> Select multiple elements <br/>
                 </div>
             </div>
-            <div id="jsoneditor" class="cdd-editor right"><!-- This is used by index.js to attach the JSON Editor object. --></div>
+            <!--Menu contains control descriptions, glossary of terms, and JSON Editor-->
+            <div id="menu" class="cdd-editor right">
+                <div id="menu-options"> <!--Menu buttons-->
+                    <div id ="menu-tabs"> <!--Menu tab buttons-->
+                        <div id="help-tab-btn" class="menu-tab">Help</div>
+                        <div id="glossary-btn" class="menu-tab">Glossary</div>
+                        <div id="advanced-tab-btn" class="menu-tab">JSON Editor</div>
+                    </div>
+                    <div id="exit-btn" class="menu-tab">Close</div> <!--Exit menu button-->
+                </div>
+                <div id="menu-contents" class="cdd-editor"> <!--Actual menu content-->
+                    <div id="helpmenu" class="info-menu"><!--Provides details about controls and buttons-->
+                        <h2>UI Buttons (Graph view)</h2>
+                        <ul>
+                            <li><b>Download</b>: Save the current CDD as a JSON file, to your local file system.</li>
+                            <li><b>New Elem</b>: Create a new decision element. The new element will be placed on the graph, with placeholder values.</li>
+                            <li><b>Del Elem</b>: Delete the selected element(s). Removes all associated dependencies as well. Can select and delete multiple elements at once.</li>
+                            <li><b>Toggle Dep</b>: When 2 or more elements are selected, toggle causal dependency arrows along the selected chain, from first selected to last selected.</li>
+                            <li><b>Menu</b>: Show menu resources such as information about controls and CDD terms, as well as the JSON Editor.</li>
+                        </ul>
+                        <h2>Controls (JSON Editor)</h2>
+                        <p>In tree view:
+                            <ul>
+                                <li><b>Double-click a value</b> to edit.</li>
+                                <li><b>Right-click</b>: View context menu.</li>
+                            </ul>
+                        </p>
+                        <h2>Load a saved JSON</h2>
+                        <p>
+                            To use your own JSON file as a starting point:
+                            <ol>
+                                <li>Delete all contents in the JSON Editor view.</li>
+                                <li>Open your JSON file in a local text editor.</li>
+                                <li>Copy the entire text contents of your local JSON file.</li>
+                                <li>Paste into this tool's JSON view.</li>
+                            </ol>
+                        </p>
+                    </div>
+                    <div id="glossary" class="info-menu"> <!--Provides definitions of CDD terminology-->
+                        <h2>Actions</h2>
+                        <p>Things that are directly within the decision maker's control.</p>
+                        <h2>Intermediates</h2>
+                        <p>Consequences of the decision maker's actions which impact the outcomes of the decision.</p>
+                        <h2>Outcomes</h2>
+                        <p>The results of a decision the decision maker is interested in measuring.</p>
+                        <h2>Externals</h2>
+                        <p>Things outside the decision maker's control that have an impact on outcomes, either directly or indirectly.</p>
+                    </div>
+                    <div id="jsoneditor"><!-- This is used by index.js to attach the JSON Editor object. --></div> <!--Default menu tab-->
+                </div>
+                
+            </div>            
         </div>
-
         <div class="instructions">
             <p>
                 This tool allows you to create and edit OpenDI standards-compliant
@@ -34,36 +85,6 @@
                 <br>
                 The tool provides a Download button to save your work as a JSON file.
                 Use it often!
-            </p>
-            <h2>Controls (Graph view)</h2>
-            <ul>
-                <li><b>Left-click</b>: Select a single decision element.</li>
-                <li><b>Left-click (drag)</b>: Move a single decision element.</li>
-                <li><b>Right-click</b>: Select multiple decision elements.</li>
-            </ul>
-            <h2>UI Buttons (Graph view)</h2>
-            <ul>
-                <li><b>Download</b>: Save the current CDD as a JSON file, to your local file system.</li>
-                <li><b>New Elem</b>: Create a new decision element. The new element will be placed on the graph, with placeholder values.</li>
-                <li><b>Del Elem</b>: Delete the selected element(s). Removes all associated dependencies as well. Can select and delete multiple elements at once.</li>
-                <li><b>Toggle Dep</b>: When 2 or more elements are selected, toggle causal dependency arrows along the selected chain, from first selected to last selected.</li>
-            </ul>
-            <h2>Controls (JSON Editor)</h2>
-            <p>In tree view:
-                <ul>
-                    <li><b>Double-click a value</b> to edit.</li>
-                    <li><b>Right-click</b>: View context menu.</li>
-                </ul>
-            </p>
-            <h2>Load a saved JSON</h2>
-            <p>
-                To use your own JSON file as a starting point:
-                <ol>
-                    <li>Delete all contents in the JSON Editor view.</li>
-                    <li>Open your JSON file in a local text editor.</li>
-                    <li>Copy the entire text contents of your local JSON file.</li>
-                    <li>Paste into this tool's JSON view.</li>
-                </ol>
             </p>
             <h2>Source</h2>
             <p>

--- a/static/style.css
+++ b/static/style.css
@@ -7,6 +7,7 @@
     height: 87.5vh;
     max-height: 87.5vh; /* Leave a little room at bottom of screen to reveal instruction text */
     min-width: 300px;
+    position: relative;
 }
 
 .left {
@@ -31,6 +32,23 @@ body {
 /* JSON Editor is closed by default. */
 #jsoneditor {
     display: none;
+}
+
+/* Graph controls legend */
+#controls-legend {
+    /* Colors */
+    background-color: rgba(0, 0, 0, 0.65);
+    color: white;
+    /* Shape */
+    border-radius: 10px;
+    padding: 15px;
+    width: auto;
+    display: inline-block;
+    /* Position */
+    position: absolute;
+    z-index: 10;
+    bottom: 15px;
+    right: 15px;
 }
 
 /* Mobile-specific (small screens) */

--- a/static/style.css
+++ b/static/style.css
@@ -10,8 +10,7 @@
 }
 
 .left {
-    width: 64%; /* Not actually used. See paper definition in index.js */
-    max-width: 64%;
+    width: 100%;
 }
 
 .right {
@@ -27,6 +26,11 @@
 
 body {
     background-color: #e2e9eb;
+}
+
+/* JSON Editor is closed by default. */
+#jsoneditor {
+    display: none;
 }
 
 /* Mobile-specific (small screens) */

--- a/static/style.css
+++ b/static/style.css
@@ -29,12 +29,80 @@ body {
     background-color: #e2e9eb;
 }
 
-/* JSON Editor is closed by default. */
+/* Entire menu */
+#menu {
+    display: none;
+    flex-direction: column;
+    background-color: #041059;
+    padding: 0;
+}
+
+/* Banner at top of menu, contains tab buttons */
+#menu-options {
+    width: 100%;
+    background-color: #000526;
+    color: white;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+/* Menu tab button */
+.menu-tab {
+    padding: 15px;
+    display: inline-block;
+}
+
+/* Underline menu tab button when user hovers over it */
+.menu-tab:hover {
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+/* JSON Editor menu contents */
 #jsoneditor {
     display: none;
 }
 
-/* Graph controls legend */
+/* Glossary menu contents */
+#glossary {
+    display: none;
+}
+
+/* Menu contents that are mostly informational (as opposed to JSON Editor) */
+.info-menu {
+    /* display: none; */
+    flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    background-color: #041059;
+    color: white;
+    padding: 0;
+}
+
+/* H2 acts like a section divider */
+.info-menu h2 {
+    background-color: #010a40;
+    margin: 0;
+    padding: 25px;
+    font-weight: normal;
+}
+
+.info-menu * {
+    font-size: 15px;
+}
+
+.info-menu p {
+    padding-left: 25px;
+    padding-right: 25px;
+}
+
+/* Highlight currently selected menu tab */
+.selected-tab {
+    background-color: #2f3ba1;
+}
+
+/* Shows description of graph controls, hovers over graph */
 #controls-legend {
     /* Colors */
     background-color: rgba(0, 0, 0, 0.65);
@@ -42,7 +110,7 @@ body {
     /* Shape */
     border-radius: 10px;
     padding: 15px;
-    width: auto;
+    /* width: auto; */
     display: inline-block;
     /* Position */
     position: absolute;


### PR DESCRIPTION
#### Description
Added graph controls legend and created a menu on the right of the graph with help contents and JSON editor that can be toggled open/close to make room for the graph. The JSON editor is still open by default.

#### Changes
* Added a "legend" which shows graph-specific controls. This is overlaid on top of the graph.
* Added a Menu button to the graph that toggles the menu open/closed.
* Reparented JSON Editor and help contents to a menu, still on the right hand side of graph.
* Added glossary of CDD terms to new menu.
* Utilized `localStorage` to save preferences about open menu tabs. These preferences are persisted in new browser windows/tabs and upon refresh of the current browser tab.

#### Issues
* Solves #8 
* Lays foundation for #2 
  * Editing of CDD element text still occurs within the JSON Editor. See #1 

#### Technical Details
This PR uses Flexbox styling (explore [here!](flexbox.tech)) and `localStorage`.

`localStorage` allows users to store key and value data, which is persisted across browser sessions, until deleted by the user (in Inspect Element). As menu tab open preferences are completely up to the user and not sensitive data, these are safe to specify as `localStorage` values. The default case—for now—is that the JSON Editor is opened in the menu upon the user's first visit to the page.

#### Areas of Interest
When reviewing this PR, please try to...
* Ensure menu tab switches work as expected.
* Delete `localStorage` entries containing the "menu" and "tab" keys or change to nonsense values. Ensure that default menu preferences work as intended.
* Ensure JSON editor edits the graph contents as expected.

#### Stretch Goals
* Change buttons to icons (i.e. gear for menu button, "X" for close menu button)
* Add alternative styling for better responsiveness (i.e. when a user accesses this page from a phone instead of a computer).